### PR TITLE
Add information about lookup file constraint.

### DIFF
--- a/lib/ansible/modules/packaging/os/apt_key.py
+++ b/lib/ansible/modules/packaging/os/apt_key.py
@@ -112,9 +112,9 @@ EXAMPLES = '''
     id: 0x473041FA
     state: absent
 
-# Add a key from a file on the Ansible server
+# Add a key from a file on the Ansible server. Use armored file since utf-8 string is expected. Must be of "PGP PUBLIC KEY BLOCK" type.
 - apt_key:
-    data: "{{ lookup('file', 'apt.gpg') }}"
+    data: "{{ lookup('file', 'apt.asc') }}"
     state: present
 
 # Add an Apt signing key to a specific keyring file


### PR DESCRIPTION
##### ISSUE TYPE
 - Docs Pull Request

##### COMPONENT NAME
apt_key module

##### ANSIBLE VERSION
```
ansible 2.2.0.0
  configured module search path = Default w/o overrides
```

##### SUMMARY

Just a small doc fix since gpg binary file cannot be include through lookup. It raises a not valid utf-8 string error.